### PR TITLE
Updating podspec to include last PR

### DIFF
--- a/PDKTStickySectionHeadersCollectionViewLayout.podspec
+++ b/PDKTStickySectionHeadersCollectionViewLayout.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
   s.name         = "PDKTStickySectionHeadersCollectionViewLayout"
-  s.version      = "0.1"
+  s.version      = "0.1.1"
   s.summary      = "UICollectionView Layout that makes section headers stick to the top of the collection view, over it's section cells."
   s.homepage     = "https://github.com/Produkt/PDKTStickySectionHeadersCollectionViewLayout"
   s.license      = 'MIT'
   s.author       = "Daniel García"
-  s.source       = { :git => "https://github.com/Produkt/PDKTStickySectionHeadersCollectionViewLayout.git", :tag => "0.1" }
+  s.source       = { :git => "https://github.com/Produkt/PDKTStickySectionHeadersCollectionViewLayout.git", :tag => s.version.to_s }
   s.platform     = :ios, '6.0'
   s.source_files = 'PDKTStickySectionHeadersCollectionViewLayout'
   s.frameworks   = 'UIKit'


### PR DESCRIPTION
@fillito please create tag 0.1.1 to be able to use last changes with CocoaPods.

After that, you can exec `pod trunk push` from the same directory to update podspec on trunk repo.

We'll be happy to continue using StickySectionHeaders in boxoffice ;)

PD: if you have any problems with CC, ping me on Twitter.
